### PR TITLE
Add onValidate to SmartError

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ The `SmartForm.Input` component will take care of any validation and, in case of
 	* `"zip"` (US 5-digit ZIP)
 * `weakValidation`: {Boolean} If this property is present, the field will only perform a weak validation. In other words, if the value in the field does not pass validation against the `validateAs` field, the `SmartForm.Error` component will still show its `invalidMsg` message, but the field will remain in a valid state, and `SmartForm.ERROR_SUSPECT` will be set as the field error instead of `SmartForm.ERROR_INVALID`. Weak validation is recommended for fields such as email address, where standards might change in the future (e.g. we didn't used to have domain suffixes greater than three characters!)
 * `defaultValue`: {String} A default value for the input field
+* `onBlur`: {Function} A callback which is invoked when the user leaves the input, and is passed three arguments:
+  * `errorReason`: {Symbol} The reason for any error. Either false (no error) or `SmartForm.ERROR_INVALID`, `SmartForm.ERROR_SUSPECT`, or `SmartForm.ERROR_REQUIRED`
+  * `value`: {String} The value of the field
+  * `props`: {Object} The props passed to the input component
+* `onFocus`: {Function} A callback which is invoked when the user enters the input, and is passed three arguments:
+  * `errorReason`: {Symbol} The reason for any error. Either false (no error) or `SmartForm.ERROR_INVALID`, `SmartForm.ERROR_SUSPECT`, or `SmartForm.ERROR_REQUIRED`
+  * `value`: {String} The value of the field
+  * `props`: {Object} The props passed to the input component
+* `onChange`: {Function} A callback which is invoked when the user changes the input value, and is passed three arguments:
+  * `errorReason`: {Symbol} The reason for any error. Either false (no error) or `SmartForm.ERROR_INVALID`, `SmartForm.ERROR_SUSPECT`, or `SmartForm.ERROR_REQUIRED`
+  * `value`: {String} The value of the field
+  * `props`: {Object} The props passed to the input component
 
 ### SmartForm.Checkbox
 

--- a/README.md
+++ b/README.md
@@ -103,5 +103,4 @@ The `SmartForm.Input` component will take care of any validation and, in case of
   * `value`: {String} The value of the field
 
 ## Future Plans (contributions welcome!)
-* The ability to fire a callback as soon as the user tabs out of a field (e.g. to check if a username is available)
 * More input types (select, textarea, etc)

--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ The `SmartForm.Input` component will take care of any validation and, in case of
 * `requiredMsg`: {String} The message to display when the field is required but empty
 * `linkedTo`: {String} **[required]** The form element the error should be linked to, in the format of `"form-id.element-id"`
 * `onError`: {Function} A callback which is invoked in case of error, and is passed two arguments:
-	* `errorReason`: {Symbol} The reason for the error. Either `SmartForm.ERROR_INVALID`, `SmartForm.ERROR_SUSPECT`, or `SmartForm.ERROR_REQUIRED`
-	* `value`: {String} The value of the field
+  * `errorReason`: {Symbol} The reason for the error. Either `SmartForm.ERROR_INVALID`, `SmartForm.ERROR_SUSPECT`, or `SmartForm.ERROR_REQUIRED`
+  * `value`: {String} The value of the field
+* `onValidate`: {Function} A callback which is invoked with the error state for every validation, and is passed two arguments:
+  * `errorReason`: {Symbol} The reason for the error. Either false (no error) or `SmartForm.ERROR_INVALID`, `SmartForm.ERROR_SUSPECT`, or `SmartForm.ERROR_REQUIRED`
+  * `value`: {String} The value of the field
 
 ## Future Plans (contributions welcome!)
 * The ability to fire a callback as soon as the user tabs out of a field (e.g. to check if a username is available)

--- a/components/SmartError.jsx
+++ b/components/SmartError.jsx
@@ -26,6 +26,13 @@ SmartForm.Error = React.createClass({
       this.props.onError(errorReason, formState.value);
     }
 
+    if(this.props.onValidate) {
+      this.props.onValidate(
+        (errorReason !== SmartForm.ERROR_NONE && errorReason),
+        (formState && formState.value)
+      );
+    }
+
     return {errorMessage}
   },
 

--- a/components/SmartInput.jsx
+++ b/components/SmartInput.jsx
@@ -57,6 +57,16 @@ SmartForm.Input = React.createClass({
       formId: this.props.formId,
       id: this.props.id
     });
+
+    let handler = (event.type === 'blur' && this.props.onBlur) || 
+                  (event.type === 'focus' && this.props.onFocus);
+    if(handler) {
+      handler(
+        (this.state && this.state.errorReason !== SmartForm.ERROR_NONE && this.state.errorReason),
+        (this.state && this.state.value),
+        this.props
+      );
+    }
   },
 
   handleChange({target}) {
@@ -68,15 +78,23 @@ SmartForm.Input = React.createClass({
       validations: this.validations,
       value: target.value
     });
+
+    if(this.props.onChange && target.value !== this.state.value) {
+      this.props.onChange(
+        (this.state && this.state.errorReason !== SmartForm.ERROR_NONE && this.state.errorReason),
+        target.value,
+        this.props
+      );
+    }
   },
 
   render() {
     return <input
+      value={this.state.value}
+      {...this.props}
       onBlur={this.handleBlurOrFocus}
       onChange={this.handleChange}
       onFocus={this.handleBlurOrFocus}
-      value={this.state.value}
-      {...this.props}
     />
   }
 });

--- a/components/SmartInput.jsx
+++ b/components/SmartInput.jsx
@@ -36,6 +36,13 @@ SmartForm.Input = React.createClass({
       valid: this.state.valid,
       value: this.state.value
     });
+
+    FormDispatcher.dispatch('SMARTFORM_INPUT_BLURORFOCUS', {
+      errorReason: this.state && this.state.errorReason,
+      event: 'blur',
+      formId: this.props.formId,
+      id: this.props.id
+    });
   },
 
   handleBlurOrFocus(event) {

--- a/components/SmartInput.jsx
+++ b/components/SmartInput.jsx
@@ -37,12 +37,14 @@ SmartForm.Input = React.createClass({
       value: this.state.value
     });
 
-    FormDispatcher.dispatch('SMARTFORM_INPUT_BLURORFOCUS', {
-      errorReason: this.state && this.state.errorReason,
-      event: 'blur',
-      formId: this.props.formId,
-      id: this.props.id
-    });
+    if(!this.props.defaultValue && !this.props.value) {
+      FormDispatcher.dispatch('SMARTFORM_INPUT_BLURORFOCUS', {
+        errorReason: this.state && this.state.errorReason,
+        event: 'blur',
+        formId: this.props.formId,
+        id: this.props.id
+      });
+    }
   },
 
   handleBlurOrFocus(event) {


### PR DESCRIPTION
Calls from same context and signature as onError, but calls even when there is no error.

Allows parent components to both set and clear error status. Example usage:

``` jsx
onValidate(fieldName, error, value) {
    let errors = (fieldName && this.state && this.state.errors && this.state.errors) || {};
    const isSet = (errors && errors[fieldName]);

    if((error && !isSet) || (!error && isSet)) {
        errors[fieldName] = !!error;
        this.setState({ 'errors': errors });
    }
},
formGroupClass(fieldName) {
    const isSet = (fieldName && this.state && this.state.errors && this.state.errors[fieldName]);
    return 'form-group' + (isSet ? ' has-error' : '');
},
render() {
    return (
        <SmartForm.Form id="interestForm" onSubmit={this.handleSubmit}>
            <div className={this.formGroupClass('name')}>
                <SmartForm.Input id="name" etc="..." />
                <SmartForm.Error
                  linkedTo="myForm.name"
                  requiredMsg="Name is required."
                  onValidate={this.onValidate.bind(this, 'name')}
                 className="help-block"
                />
            </div>
        </SmartForm.Form>
    )
}
```
